### PR TITLE
feat(zkvmLib): Proper Cargo.lock generation

### DIFF
--- a/guests/README.md
+++ b/guests/README.md
@@ -11,8 +11,6 @@ These are normal Rust programs, with certain specific patterns implemented for z
 
 1. **Copy the project to this directory.**
 
-   Make sure the directory name is the **same** as the package name (inside your `Cargo.toml`)!
-
    If you refer to local path dependencies, which you want to include with the project, move them inside the `guest/YOUR_PROJECT/` directory!
    Everything directly inside `guests` is expected to be a crate, setup to be ran by the zkVMs.
 

--- a/zkvmLib.nix
+++ b/zkvmLib.nix
@@ -15,7 +15,6 @@ pkgs: guest: let
           tail -n +4 ./guest/Cargo.lock >> "$out/Cargo.lock"
           tail -n +4 ../../guests/${guest}/Cargo.lock >> "$out/Cargo.lock"
 
-          cp ./guest/Cargo.lock "$out/Guest-Cargo.lock"
         '';
       };
 
@@ -31,7 +30,9 @@ in {
         ${args.postUnpack or ""}
         ln -s ../../../guests ./source/zkvms/${args.pname}/guest/
         ln -s ../../../guests_macro ./source/zkvms/${args.pname}/guest/
-        ln -s '${cargoLocks.cargoLockDrv}/Guest-Cargo.lock' ./source/zkvms/${args.pname}/guest/Cargo.lock
+
+        cp '${cargoLocks.cargoLockDrv}/Cargo.lock' ./source/zkvms/${args.pname}/guest/Cargo.lock
+        chmod +w ./source/zkvms/${args.pname}/guest/Cargo.lock
       '';
 
       preBuild = ''

--- a/zkvmLib.nix
+++ b/zkvmLib.nix
@@ -106,14 +106,12 @@ in {
     pname = "${args.pname}_${guest}";
   in craneLib.buildPackage ((generateCargoLocks craneLib args) // {
     phases = [
-      "unpackPhase" # Standard phases
-      "linkGuest" # Custom phase
-      "patchPhase" "configurePhase" # Standard phases
-      "buildGuestPhase" # Custom phase
+      "unpackPhase" "patchPhase" "configurePhase" # Standard phases
+      "cargoSetupGuest" "buildGuestPhase" # Custom phases
       "buildPhase" "checkPhase" "installPhase" "fixupPhase" # Standard phases
     ];
 
-    linkGuest = let
+    cargoSetupGuest = let
       appended = ''
         zkp = { path = "../../../guests/${guest}", package = "${guest}" }
 
@@ -123,6 +121,11 @@ in {
       '';
     in ''
       echo '${appended}' >> zkvms/${args.pname}/guest/Cargo.toml
+      pushd zkvms/${args.pname}/guest
+
+      echo '${appended}' >> Cargo.toml
+
+      popd
     '';
 
     buildGuestPhase = ''


### PR DESCRIPTION
Now we can specify dependencies in the guest implementation and they will be correctly handled.

As a nice side-effect, we don't need to require guest implementation names (in Cargo.toml) to match with directory names.