### PR TITLE
feat: Add zkvm cargo features

### DIFF
--- a/guests/README.md
+++ b/guests/README.md
@@ -26,13 +26,19 @@ These are normal Rust programs, with certain specific patterns implemented for z
    guests_macro = { version = "0.1.0", path = "../../guests_macro" }
    ```
 
-   and add a `no_std` [feature](https://doc.rust-lang.org/cargo/reference/features.html) like this:
+   and add a `no_std` and zkVM [features](https://doc.rust-lang.org/cargo/reference/features.html) like this:
 
    ```toml
    no_std = []
+   jolt = []
+   nexus = []
+   risc0 = []
+   sp1 = []
+   zkm = []
+   zkwasm = []
    ```
 
-   It's ok if you don't conditionally include anything with the feature, however it **must** exist!
+   It's ok if you don't use those features in any way, however they **must** exist!
 
 4. **Update your program.**
 

--- a/guests/fibonacci/Cargo.toml
+++ b/guests/fibonacci/Cargo.toml
@@ -8,3 +8,9 @@ guests_macro = { version = "0.1.0", path = "../../guests_macro" }
 
 [features]
 no_std = []
+jolt = []
+nexus = []
+risc0 = []
+sp1 = []
+zkm = []
+zkwasm = []

--- a/guests/graph_coloring/Cargo.toml
+++ b/guests/graph_coloring/Cargo.toml
@@ -8,3 +8,9 @@ guests_macro = { version = "0.1.0", path = "../../guests_macro" }
 
 [features]
 no_std = []
+jolt = []
+nexus = []
+risc0 = []
+sp1 = []
+zkm = []
+zkwasm = []

--- a/zkvmLib.nix
+++ b/zkvmLib.nix
@@ -133,6 +133,7 @@ in {
         [features]
         guest = [] # Only used in jolt
         no_std = ["zkp/no_std"]
+        ${args.pname} = ["zkp/${args.pname}"]
       '';
     in ''
       pushd zkvms/${args.pname}/guest
@@ -154,7 +155,7 @@ in {
       pushd zkvms/${args.pname}/guest
       runHook preBuildGuest
 
-      ${args.buildGuestCommand or "cargo build --release"} \
+      ${args.buildGuestCommand or "cargo build --release --features ${args.pname}"} \
           ${if args ? guestTarget then "--target " + args.guestTarget else ""} \
           ${args.guestExtraArgs or ""}
 

--- a/zkvms/zkwasm/default.nix
+++ b/zkvms/zkwasm/default.nix
@@ -47,7 +47,7 @@ in
         export WASM_PACK_CACHE=.wasm-pack-cache
       '';
 
-      buildGuestCommand = "wasm-pack build --release --frozen";
+      buildGuestCommand = "wasm-pack build --release --frozen --features zkwasm";
 
       preBuild = ''
         export GUEST_PATH="$out/pkg/guest_bg.wasm"


### PR DESCRIPTION
Add a cargo feature to all guests, which is enabled according to the zkVM. Thus, you're able to do conditional compilation and chose optional dependencies, depending on the zkVM.