### PR TITLE
flake: use Attic cache for zkVM benchmarks

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,8 @@
   description = "zkVMs benchmarks";
 
   nixConfig = {
-    extra-substituters = "https://nix-blockchain-development.cachix.org";
-    extra-trusted-public-keys = "nix-blockchain-development.cachix.org-1:Ekei3RuW3Se+P/UIo6Q/oAgor/fVhFuuuX5jR8K/cdg=";
+    extra-substituters = "https://cache.metacraft-labs.com/metacraft-public";
+    extra-trusted-public-keys = "metacraft-public:UtS6PK+p0uZaJK3i/jD2DQOjTpddhQUQmNQDQih5N4Q=";
   };
 
   inputs = {


### PR DESCRIPTION
## Summary
- replace the zkVM benchmarks Cachix nixConfig with the metacraft-public Attic substituter and public key

## Verification
- /home/zahary/metacraft/nixos-modules/scripts/attic-migrate-flake --check .
- nix flake show --accept-flake-config
- git diff --check
- tracked residual Cachix search: no cachix.org matches

## Note
- `nix flake check --no-build --accept-flake-config` still fails in `packages.x86_64-linux.update-nix-dependencies` with `path /nix/store/fh13pc5x74ksp4whjx9zlql7skadq8hc-source.drv is not valid`; the same failure reproduces on origin/main, so it is pre-existing and unrelated to this cache migration.